### PR TITLE
Make Desktop App download links static :atm:

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,17 +170,35 @@ home: true
         <div class="download">
           <img class="os-logo" src="./dist/images/apple-logo.png" />
           <img class="download-icon" src="./dist/images/download-file.png" />
-          <a id="download-link-macos" download>macOS 10.10+</a>
+          <a
+						id="download-link-macos"
+						href="https://github.com/ibm-apiconnect/test-and-monitor/releases/download/v1.0.0/apic-test-and-monitor.dmg"
+						download
+					>
+						macOS 10.10+
+					</a>
         </div>
         <div class="download">
           <img class="os-logo" src="./dist/images/windows-logo.png" />
           <img class="download-icon" src="./dist/images/download-file.png" />
-          <a id="download-link-windows" download>Windows 10</a>
+          <a
+						id="download-link-windows"
+						href="https://github.com/ibm-apiconnect/test-and-monitor/releases/download/v1.0.0/apic-test-and-monitor.exe"
+						download
+					>
+						Windows 10
+					</a>
         </div>
         <div class="download">
           <img class="os-logo" src="./dist/images/linux-logo.png" />
           <img class="download-icon" src="./dist/images/download-file.png" />
-          <a id="download-link-linux" download>Linux</a>
+          <a
+						id="download-link-linux"
+						href="https://github.com/ibm-apiconnect/test-and-monitor/releases/download/v1.0.0/apic-test-and-monitor.AppImage"
+						download
+					>
+						Linux
+					</a>
         </div>
         <div id="download-links-error" class="error hide"></div>
       </div>

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -1,19 +1,5 @@
 $(document).foundation();
 
-function generateDownloadURLs(data) {
-  if (!data.assets || !data.assets.length) return;
-
-  data.assets.forEach(function(asset) {
-    if (/\.exe$/.test(asset.name)) {
-      document.getElementById('download-link-windows').setAttribute('href', asset.browser_download_url);
-    } else if (/\.dmg$/.test(asset.name)) {
-      document.getElementById('download-link-macos').setAttribute('href', asset.browser_download_url);
-    } else if (/\.AppImage$/.test(asset.name)) {
-      document.getElementById('download-link-linux').setAttribute('href', asset.browser_download_url);
-    }
-  });
-}
-
 function trackDownload(file) {
 	window.bluemixAnalytics.trackEvent("Downloaded Hybrid Solution",{
 	    productTitle: digitalData.page.pageInfo.productTitle,
@@ -27,16 +13,6 @@ function trackDownload(file) {
 }
 
 $(document).ready(function(){
-  // generate download urls for Desktop client
-  fetch("https://api.github.com/repos/ibm-apiconnect/test-and-monitor/releases/latest")
-    .then(function(response) { return response.json() })
-    .then(generateDownloadURLs)
-    .catch(function(error) {
-      $('#download-links-error')
-        .html("* Error getting download links, please try reloading this page.")
-        .removeClass('hide');
-    });
-
     $(".trackdownload").on("click", function(e) {
         var file=$(this).attr('href');
         trackDownload(file);


### PR DESCRIPTION
- Github rate limits API calls that were used to generate the links.
- Make the download links static.
- We'll have to update those for every public release.